### PR TITLE
Update underlying styles to be less opinionated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-A set of tools to build extensible layouts using [CSS grid](https://developer.mozilla.org/en-US/docs/Web/CSS/grid) specification. 
+A set of tools to build extensible layouts using [CSS grid](https://developer.mozilla.org/en-US/docs/Web/CSS/grid) specification.
 
 React-Grits attempts to reduce the complexity in sharing, debugging, and previewing standardized layouts by providing a thin layer on top of CSS grid.
 
@@ -10,23 +10,37 @@ React-Grits attempts to reduce the complexity in sharing, debugging, and preview
 
 `npm install react-grits`
 
-or through yarn 
+or through yarn
 
 `yarn add react-grits`
 
 # API
 
 Helpers
-- createGridItemsForChildren
-- createGridWithProps
-- debug
-- validate
+- `createGridItemsForChildren`
+    - Arguments:
+        - `children`: React node or array of nodes
+        - `WrapperComponent`: Optional component to wrap each item. Defaults to GridItem.
+- `createGridWithProps`
+    - Arguments:
+        - `props`: A set of configuration properties to provide to the grid component:
+            - `templateAreas`: a nested array of named template areas
+            - `templateColumns`: an string list of column sizes
+            - `templateRows`: an string list of row sizes
+            - `columnGap`: a string to define the gap size between columns
+            - `rowGap`: a string to define the gap size between rows
+        - `components`: A set of components which can be used to override rendering
+            - `GridComponent`: a component which defines the grid layout
+            - `ItemComponent`: a component which will wrap all children
+            - See [this section](#Customizing-Layout-Components) for more information
+- `debug`: a higher-order component which wraps a layout created with `createGridWithProps` and enables debugging by passing a `debug=true` prop
+- `validate`: a function which creates a higher-order component that will validate the number of children passed to a layout
 
 Components
 - Grid
 - GridItem
 
-Pre-defined templates 
+Pre-defined templates
 - SplitHalf
 - AsideLeft
 - AsideRight
@@ -55,13 +69,13 @@ const MyPage = () => (
     <MainContent gridArea="view1" />
   </AsideLeft>
 )
- 
+
 ```
 
 
 # Defining a custom layout
 ```jsx
-import {Grid} from 'react-grits';
+import { validate, createGridWithProps, debug } from 'react-grits';
 
 // start by defining your template areas
 const templateAreas = [
@@ -96,14 +110,14 @@ Provides a left sidebar and a main region seperated a column gap. This is a comm
 ```jsx
 import {AsideLeft} from 'react-grits';
 
-<AsideLeft> 
+<AsideLeft>
    <Side gridArea="view1" />
    <Master gridArea="view2" />
 </AsideLeft>
 ```
 
 ## Aside Right
-Provides a right sidebar and a main region with a configurable gap distance. 
+Provides a right sidebar and a main region with a gap between columns.
 
 ![AsideRight](docs/asideright.png)
 
@@ -112,7 +126,7 @@ Provides a right sidebar and a main region with a configurable gap distance.
 ```jsx
 import {AsideRight} from 'react-grits';
 
-<AsideRight>    
+<AsideRight>
    <Master gridArea="view1" />
    <Side gridArea="view2" />
 </AsideRight>
@@ -128,7 +142,7 @@ Splits each view equally into two columns seperated by a column gap.
 ```jsx
 import {SplitHalf} from 'react-grits';
 
-<SplitHalf> 
+<SplitHalf>
    <FooView gridArea="view1" />
    <BarView gridArea="view2" />
 </SplitHalf>
@@ -145,13 +159,29 @@ Provides a three column approach where each column has an equal width and an equ
 ```jsx
 import {Thirds} from 'react-grits';
 
-<Thirds> 
+<Thirds>
    <ACol gridArea="view1" />
    <BCol gridArea="view2" />
    <CCol gridArea="view3" />
 </Thirds>
 ```
 
+# Customizing Layout Components
+The library ships with underlying components which handle defining the CSS grid layout using reasonable default behaviors.
+
+If you want to customize the styles of either the containing Grid component, or the Item components which wrap each child within a layout, you may pass overriding components to the `createGridWithProps` function when you define your layout.
+
+`createGridWithProps({ GridComponent: MyCustomGrid, ItemComponent: MyCustomItem });`
+
+Each component is passed certain props which you can use to define your styling. The library exports the default components as `Grid` and `GridItem`. They are created using `styled-components`, and can be extended or wrapped if you want to build on top of existing styles.
+
+## Grid
+
+The Grid component receives the provided `templateColumns`, `templateRows`, `columnGap`, `rowGap` props. It also receives a parsed version of `templateAreas` which is ready to be used as a CSS property value. Finally, any further props which are passed through by the user are supplied to Grid, including `style` and other common props.
+
+## GridItem
+
+The item component will automatically be used to wrap all children in a layout. It receives one prop, `gridArea`, which is supplied by the user to the wrapped child. Use this prop as a CSS value to put the component into its proper grid space. You may also use it to define some custom logic if you wish.
 
 # License
 

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -1,61 +1,59 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
-const mapGridTemplateAreas = ({templateAreas = []}) => 
+const mapGridTemplateAreas = ({templateAreas = []}) =>
     templateAreas.reduce((line, area) => line + `"${area.join(' ')}"`, '');
-
-const count = ({templateAreas = []}) => (templateAreas.length);
 
 export const Grid = styled.div`
     display: grid;
-    grid-template-columns: auto;
     grid-auto-rows: minmax(100px, auto);
-    grid-template-areas: ${mapGridTemplateAreas};
-    min-width: 100vw;
-    min-height: 100vh;
+    grid-template-areas: ${props => props.templateAreas};
     grid-column-gap: ${props => props.columnGap || 'initial'};
-    grid-template-columns: ${props => props.templateColumns};
-
+    grid-template-columns: ${props => props.templateColumns || 'initial'};
+    grid-template-rows: ${props => props.templateRows || 'initial'};
+    grid-row-gap: ${props => props.rowGap || 'initial'};
 
     ${props => props.style}
-    
 `
 
 export const GridItem = styled.div`
   grid-column: ${props => props.gridColumn || "auto"};
   grid-row: ${props => props.gridRow || "auto"};
   grid-area: ${props => props.gridArea || ""};
-  ${props => props.style} ${props =>
-      props.borderRight && "border-right: 1px solid #c2c2c2;"};
-
-  @media only screen and (min-width: 1500px) {
-    border-right: none !important;
-  }
-  
   box-sizing: border-box;
 `;
 
-const gridItem =  child => {
+const gridItem = WrapperComponent => child => {
   const {gridArea = ".", ...rest} = child.props;
   return (
-    <GridItem gridArea={gridArea}>
+    <WrapperComponent gridArea={gridArea}>
       {React.createElement(child.type, { ...rest }, child.props.children)}
-    </GridItem>
+    </WrapperComponent>
   );
-} 
+}
 
-export const createGridItemsForChildren = children =>
-  React.Children.map(children, gridItem);
+export const createGridItemsForChildren = (children, WrapperComponent = GridItem) =>
+  React.Children.map(children, gridItem(WrapperComponent));
 
-export const createGridWithProps = ({templateAreas, templateColumns, columnGap}) => ({ children, ...rest }) => {
+export const createGridWithProps = ({
+  templateAreas,
+  templateColumns,
+  templateRows,
+  columnGap,
+  rowGap,
+}, components = {}) => ({ children, ...rest }) => {
+  const GridComponent = components.GridComponent || Grid;
+  const ItemComponent = components.ItemComponent || GridItem;
   return (
-    <Grid
-      templateAreas={templateAreas}
+    <GridComponent
+      templateAreas={mapGridTemplateAreas(templateAreas)}
       templateColumns={templateColumns}
       columnGap={columnGap}
+      templateRows={templateRows}
+      rowGap={rowGap}
       {...rest}
     >
-      {createGridItemsForChildren(children)}      
-    </Grid>
+      {createGridItemsForChildren(children, ItemComponent)}
+    </GridComponent>
   );
 };

--- a/src/Validate.js
+++ b/src/Validate.js
@@ -4,7 +4,7 @@ import ErrorBox from "./Error";
 export default options => Component => props => {
   const count = React.Children.count(props.children);
   if (options.minChildren && count < options.minChildren) {
-    const e = new Error(`Expected 3 elements, received ${count}`);
+    const e = new Error(`Expected ${options.minChildren} elements, received ${count}`);
     return <ErrorBox error={e} />;
   }
 

--- a/src/templates/AsideLeft.js
+++ b/src/templates/AsideLeft.js
@@ -6,7 +6,7 @@ import debug from '../Debugger';
 const templateAreas = [
   ["view1", "view2"]
 ];
-const templateColumns = "30% 70%";
+const templateColumns = "3fr 7fr";
 const columnGap = "30px";
 
 const validator = validate({minChildren: 2});

--- a/src/templates/AsideRight.js
+++ b/src/templates/AsideRight.js
@@ -4,7 +4,7 @@ import validate from "../Validate";
 import debug from "../Debugger";
 
 const templateAreas = [["view1", "view2"]];
-const templateColumns = "70% 30%";
+const templateColumns = "7fr 3fr";
 const columnGap = "30px";
 
 const validator = validate({minChildren: 2});

--- a/src/templates/SplitHalf.js
+++ b/src/templates/SplitHalf.js
@@ -6,7 +6,7 @@ import debug from "../Debugger";
 const templateAreas = [
   ["view1", "view2"]
 ];
-const templateColumns = "50% 50%";
+const templateColumns = "1fr 1fr";
 const columnGap = "30px";
 
 const validator = validate({minChildren: 2});

--- a/src/templates/Thirds.js
+++ b/src/templates/Thirds.js
@@ -6,7 +6,7 @@ import debug from "../Debugger";
 const templateAreas = [
   ["view1", "view2", "view3"]
 ];
-const templateColumns = "30% 30% 30%";
+const templateColumns = "1fr 1fr 1fr";
 const columnGap = "30px";
 
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -3,17 +3,96 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 
-import AsideRight from "../src/templates/AsideRight";
-import Box from '../src/Box';
+import { AsideRight, AsideLeft, Thirds, SplitHalf } from "../src";
 
-storiesOf("Layouts", module).add("with Third", () => (
-  <AsideRight debug>
-    <div gridArea="master">
-      <h1>test</h1>
-      <div>
-        <label>butter</label>
+storiesOf("Layouts", module)
+  .add("SplitHalf", () => (
+    <SplitHalf>
+      <div gridArea="view1">
+        <h1>test</h1>
+        <div>
+          <label>butter</label>
+        </div>
       </div>
-    </div>
-    <div gridArea="detail"><h2>test3</h2></div>
-  </AsideRight>
-));
+      <div gridArea="view2"><h2>test3</h2></div>
+    </SplitHalf>
+  ))
+  .add("SplitHalf debug", () => (
+    <SplitHalf debug>
+      <div gridArea="view1">
+        <h1>test</h1>
+        <div>
+          <label>butter</label>
+        </div>
+      </div>
+      <div gridArea="view2"><h2>test3</h2></div>
+    </SplitHalf>
+  ))
+  .add("AsideRight", () => (
+    <AsideRight>
+      <div gridArea="view1">
+        <h1>test</h1>
+        <div>
+          <label>butter</label>
+        </div>
+      </div>
+      <div gridArea="view2"><h2>test3</h2></div>
+    </AsideRight>
+  ))
+  .add("AsideRight debug", () => (
+    <AsideRight debug>
+      <div gridArea="view1">
+        <h1>test</h1>
+        <div>
+          <label>butter</label>
+        </div>
+      </div>
+      <div gridArea="view2"><h2>test3</h2></div>
+    </AsideRight>
+  ))
+  .add("AsideLeft", () => (
+    <AsideLeft>
+      <div gridArea="view1">
+        <h1>test</h1>
+        <div>
+          <label>butter</label>
+        </div>
+      </div>
+      <div gridArea="view2"><h2>test3</h2></div>
+    </AsideLeft>
+  ))
+  .add("AsideLeft debug", () => (
+    <AsideLeft debug>
+      <div gridArea="view1">
+        <h1>test</h1>
+        <div>
+          <label>butter</label>
+        </div>
+      </div>
+      <div gridArea="view2"><h2>test3</h2></div>
+    </AsideLeft>
+  ))
+  .add("Thirds", () => (
+    <Thirds>
+      <div gridArea="view1">
+        <h1>test</h1>
+        <div>
+          <label>butter</label>
+        </div>
+      </div>
+      <div gridArea="view2"><h2>test3</h2></div>
+      <div gridArea="view3">Third panel</div>
+    </Thirds>
+  ))
+  .add("Thirds debug", () => (
+    <Thirds debug>
+      <div gridArea="view1">
+        <h1>test</h1>
+        <div>
+          <label>butter</label>
+        </div>
+      </div>
+      <div gridArea="view2"><h2>test3</h2></div>
+      <div gridArea="view3">Third panel</div>
+    </Thirds>
+  ));


### PR DESCRIPTION
* Fixed outdated storybook
* Add more docs
* Update layout creation to support [customizable rendering](https://medium.com/@gaforres/react-redux-pattern-customizable-behavioral-components-359b4adbf380)

New changes mean that layouts will no longer take up 100vw/vh. I found that to be too big of an assumption for most use cases. Now, it's up to the developer to place the layout component within a container which will fill the desired space.

I also updated the layout prefabs to use `fr` units, since they accommodate the column gaps, whereas set percentage makes the columns overflow.